### PR TITLE
Fix build documentation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,11 @@ compile('com.google.apis:google-api-services-sheets:v4-rev466-1.22.0') {
     exclude group: 'org.apache.httpcomponents'
     exclude group: 'com.google.code.findbugs'
 }
+compile 'com.google.android.gms:play-services-drive:10.2.1'
+compile('com.google.apis:google-api-services-drive:v3-rev69-1.22.0') {
+    exclude group: 'org.apache.httpcomponents'
+    exclude group: 'com.google.code.findbugs'
+}
 ```
 
 Now it should look something like this.
@@ -138,6 +143,11 @@ dependencies {
         exclude group: 'com.google.code.findbugs'
     }
     compile('com.google.apis:google-api-services-sheets:v4-rev466-1.22.0') {
+        exclude group: 'org.apache.httpcomponents'
+        exclude group: 'com.google.code.findbugs'
+    }
+    compile 'com.google.android.gms:play-services-drive:10.2.1'
+    compile('com.google.apis:google-api-services-drive:v3-rev69-1.22.0') {
         exclude group: 'org.apache.httpcomponents'
         exclude group: 'com.google.code.findbugs'
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,6 +26,20 @@ dependencies {
     })
     compile 'com.android.support:appcompat-v7:25.3.1'
     compile 'com.android.support.constraint:constraint-layout:1.0.1'
+    compile 'com.google.android.gms:play-services-auth:10.2.1'
+    compile('com.google.api-client:google-api-client-android:1.22.0') {
+        exclude group: 'org.apache.httpcomponents'
+        exclude group: 'com.google.code.findbugs'
+    }
+    compile('com.google.apis:google-api-services-sheets:v4-rev466-1.22.0') {
+        exclude group: 'org.apache.httpcomponents'
+        exclude group: 'com.google.code.findbugs'
+    }
+    compile 'com.google.android.gms:play-services-drive:10.2.1'
+    compile('com.google.apis:google-api-services-drive:v3-rev69-1.22.0') {
+        exclude group: 'org.apache.httpcomponents'
+        exclude group: 'com.google.code.findbugs'
+    }
     testCompile 'junit:junit:4.12'
     compile project(':sheets436')
 }


### PR DESCRIPTION
Fixes #21. External builds need an additional Drive dependency in `build.gradle`. This PR documents that.

```
compile 'com.google.android.gms:play-services-drive:10.2.1'
compile('com.google.apis:google-api-services-drive:v3-rev69-1.22.0') {
    exclude group: 'org.apache.httpcomponents'
    exclude group: 'com.google.code.findbugs'
}
```