### PR TITLE
Add methods to read prescriptions and download APKs

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,7 +25,7 @@ dependencies {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
     compile 'com.android.support:appcompat-v7:25.3.1'
-    compile 'com.android.support.constraint:constraint-layout:1.0.1'
+    compile 'com.android.support.constraint:constraint-layout:1.0.2'
     testCompile 'junit:junit:4.12'
     compile project(':sheets436')
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,7 +25,6 @@ dependencies {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
     compile 'com.android.support:appcompat-v7:25.3.1'
-    compile 'com.android.support.constraint:constraint-layout:1.0.2'
     compile 'com.android.support.constraint:constraint-layout:1.0.1'
     compile 'com.google.android.gms:play-services-auth:10.2.1'
     compile('com.google.api-client:google-api-client-android:1.22.0') {

--- a/app/src/main/java/edu/umd/sheets436/MainActivity.java
+++ b/app/src/main/java/edu/umd/sheets436/MainActivity.java
@@ -161,10 +161,4 @@ public class MainActivity extends AppCompatActivity implements Sheets.Host {
         }
         Log.i(getClass().getSimpleName(), "Done");
     }
-
-    @Override
-    public void onPrescriptionReady(List<String> result) {
-
-    }
-
 }

--- a/app/src/main/java/edu/umd/sheets436/MainActivity.java
+++ b/app/src/main/java/edu/umd/sheets436/MainActivity.java
@@ -3,10 +3,10 @@ package edu.umd.sheets436;
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+import android.os.Bundle;
 import android.os.StrictMode;
 import android.support.annotation.NonNull;
 import android.support.v7.app.AppCompatActivity;
-import android.os.Bundle;
 import android.util.Log;
 import android.view.View;
 import android.widget.ArrayAdapter;
@@ -15,7 +15,6 @@ import android.widget.Spinner;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
-import java.util.List;
 
 import edu.umd.cmsc436.sheets.Sheets;
 

--- a/app/src/main/java/edu/umd/sheets436/MainActivity.java
+++ b/app/src/main/java/edu/umd/sheets436/MainActivity.java
@@ -15,6 +15,7 @@ import android.widget.Spinner;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.util.List;
 
 import edu.umd.cmsc436.sheets.Sheets;
 
@@ -159,6 +160,11 @@ public class MainActivity extends AppCompatActivity implements Sheets.Host {
             throw new RuntimeException(e);
         }
         Log.i(getClass().getSimpleName(), "Done");
+    }
+
+    @Override
+    public void onPrescriptionReady(List<String> result) {
+
     }
 
 }

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0'
+        classpath 'com.android.tools.build:gradle:2.3.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/sheets436/build.gradle
+++ b/sheets436/build.gradle
@@ -8,7 +8,7 @@ android {
         minSdkVersion 22
         targetSdkVersion 25
         versionCode 1
-        versionName "0.0.7-prescription"
+        versionName "0.0.8-prescription"
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         archivesBaseName = "${archivesBaseName}-" + versionName

--- a/sheets436/build.gradle
+++ b/sheets436/build.gradle
@@ -8,7 +8,7 @@ android {
         minSdkVersion 22
         targetSdkVersion 25
         versionCode 1
-        versionName "0.0.6-prescription"
+        versionName "0.0.7-prescription"
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         archivesBaseName = "${archivesBaseName}-" + versionName

--- a/sheets436/build.gradle
+++ b/sheets436/build.gradle
@@ -8,7 +8,7 @@ android {
         minSdkVersion 22
         targetSdkVersion 25
         versionCode 1
-        versionName "0.0.5"
+        versionName "0.0.6-prescription"
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         archivesBaseName = "${archivesBaseName}-" + versionName

--- a/sheets436/build.gradle
+++ b/sheets436/build.gradle
@@ -8,7 +8,7 @@ android {
         minSdkVersion 22
         targetSdkVersion 25
         versionCode 1
-        versionName "0.0.6-prescription"
+        versionName "0.0.7"
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         archivesBaseName = "${archivesBaseName}-" + versionName

--- a/sheets436/build.gradle
+++ b/sheets436/build.gradle
@@ -8,7 +8,7 @@ android {
         minSdkVersion 22
         targetSdkVersion 25
         versionCode 1
-        versionName "0.0.8-prescription"
+        versionName "0.0.6-prescription"
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         archivesBaseName = "${archivesBaseName}-" + versionName

--- a/sheets436/src/main/java/edu/umd/cmsc436/sheets/DriveApkTask.java
+++ b/sheets436/src/main/java/edu/umd/cmsc436/sheets/DriveApkTask.java
@@ -1,0 +1,116 @@
+package edu.umd.cmsc436.sheets;
+
+import android.app.Activity;
+import android.util.Log;
+
+import com.google.api.client.googleapis.extensions.android.gms.auth.GoogleAccountCredential;
+import com.google.api.services.drive.model.FileList;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Task to use the REST API to download files
+ */
+
+public class DriveApkTask extends UploadToDriveTask {
+
+    private OnFinishListener mListener;
+    private Map<String, Float> mVersionMap;
+
+    public DriveApkTask(GoogleAccountCredential credential, String applicationName, Sheets.Host host, Activity hostActivity) {
+        super(credential, applicationName, host, hostActivity);
+    }
+
+    public DriveApkTask setOnFinishListener (OnFinishListener listener) {
+        mListener = listener;
+        return this;
+    }
+
+    // type -> version, or -1 if want to guarantee update (aka install)
+    public DriveApkTask setVersionMap(Map<String, Float> infoList) {
+        mVersionMap = infoList;
+        return this;
+    }
+
+    @Override
+    protected Exception doInBackground(DrivePayload... params) {
+        if (!(params.length > 0)) {
+            return new Exception("need a DrivePayload with a folder id");
+        }
+
+        String folderId = params[0].folderId;
+        Map<String, Float> max_versions = new HashMap<>();
+        Map<String, com.google.api.services.drive.model.File> type_to_file = new HashMap<>();
+
+        // list all files
+        // TODO only gets the first 100 files, but I'm not going to worry about > 100 APKs right now
+        try {
+            FileList files = driveService.files().list()
+                    .setQ("'" + folderId + "' in parents")
+                    .execute();
+
+            List<com.google.api.services.drive.model.File> realFiles = files.getFiles();
+            if (realFiles == null) {
+                return new Exception("files null");
+            }
+
+            // get max versions
+            for (com.google.api.services.drive.model.File f : realFiles) {
+                String name = f.getName();
+                float version = getVersionFromName(name);
+                if (!max_versions.containsKey(name) || version > max_versions.get(name)) {
+                    max_versions.put(name, version);
+                    type_to_file.put(name.substring(0, name.lastIndexOf('-')), f);
+                }
+            }
+
+            // find which to actually download
+            List<com.google.api.services.drive.model.File> toDownload = new ArrayList<>();
+
+            for (String fname : max_versions.keySet()) {
+                Log.i(getClass().getCanonicalName(), "max version: " + fname);
+                String type = fname.substring(0, fname.lastIndexOf('-'));
+                if (mVersionMap.containsKey(type) && mVersionMap.get(type) < max_versions.get(fname)) {
+                    toDownload.add(type_to_file.get(type));
+                }
+            }
+
+            List<File> results = new ArrayList<>();
+            Log.i(getClass().getCanonicalName(), "#files to download: " + toDownload.size());
+            for (com.google.api.services.drive.model.File f : toDownload) {
+                File outputFile = File.createTempFile(f.getName(), "", hostActivity.getCacheDir());
+                FileOutputStream fileOutputStream = new FileOutputStream(outputFile);
+                driveService.files().get(f.getId()).executeMediaAndDownloadTo(fileOutputStream);
+                results.add(outputFile);
+            }
+
+            if (mListener != null) {
+                mListener.onFinish(results);
+            }
+        } catch (IOException e) {
+            return e;
+        }
+
+        return null;
+    }
+
+    private float getVersionFromName(String name) {
+        String version = name.substring(name.lastIndexOf('-') + 1, name.lastIndexOf('.'));
+
+        try {
+            return Float.parseFloat(version);
+        } catch (NumberFormatException nfe) {
+            return -1;
+        }
+    }
+
+    public interface OnFinishListener {
+        void onFinish(List<File> tempFiles);
+    }
+}

--- a/sheets436/src/main/java/edu/umd/cmsc436/sheets/DriveApkTask.java
+++ b/sheets436/src/main/java/edu/umd/cmsc436/sheets/DriveApkTask.java
@@ -75,14 +75,14 @@ public class DriveApkTask extends UploadToDriveTask {
             Log.i(getClass().getCanonicalName(), "Number of files to download: " + filesToGet.keySet().size());
 
             // Actually download
-            List<File> results = new ArrayList<>();
+            Map<File, Float> results = new HashMap<>();
             for (com.google.api.services.drive.model.File f : filesToGet.values()) {
                 File tempFile = File.createTempFile(removeExtension(f), ".apk", hostActivity.getCacheDir());
                 FileOutputStream fileOutputStream = new FileOutputStream(tempFile);
 
                 driveService.files().get(f.getId()).executeMediaAndDownloadTo(fileOutputStream);
 
-                results.add(tempFile);
+                results.put(tempFile, getVersion(f));
             }
 
             if (mListener != null) {
@@ -117,6 +117,6 @@ public class DriveApkTask extends UploadToDriveTask {
     }
 
     public interface OnFinishListener {
-        void onFinish(List<File> tempFiles);
+        void onFinish(Map<File, Float> tempFiles);
     }
 }

--- a/sheets436/src/main/java/edu/umd/cmsc436/sheets/ReadPrescriptionTask.java
+++ b/sheets436/src/main/java/edu/umd/cmsc436/sheets/ReadPrescriptionTask.java
@@ -70,7 +70,7 @@ public class ReadPrescriptionTask extends AsyncTask<String, Void, Exception> {
                 }
 
                 ValueRange vals = sheetsService.spreadsheets().values()
-                        .get(spreadsheetId, "Sheet1!A" + cur_row + ":M" + cur_row)
+                        .get(spreadsheetId, "Sheet1!A" + cur_row + ":N" + cur_row)
                         .execute();
 
                 sheet = vals.getValues();

--- a/sheets436/src/main/java/edu/umd/cmsc436/sheets/ReadPrescriptionTask.java
+++ b/sheets436/src/main/java/edu/umd/cmsc436/sheets/ReadPrescriptionTask.java
@@ -70,7 +70,7 @@ public class ReadPrescriptionTask extends AsyncTask<String, Void, Exception> {
                 }
 
                 ValueRange vals = sheetsService.spreadsheets().values()
-                        .get(spreadsheetId, "Sheet1!A" + cur_row + ":N" + cur_row)
+                        .get(spreadsheetId, "Sheet1!A" + cur_row + ":P" + cur_row)
                         .execute();
 
                 sheet = vals.getValues();

--- a/sheets436/src/main/java/edu/umd/cmsc436/sheets/ReadPrescriptionTask.java
+++ b/sheets436/src/main/java/edu/umd/cmsc436/sheets/ReadPrescriptionTask.java
@@ -17,7 +17,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Read a prescription object and return a row of data in the form of a list of strings to interpret
+ * Return the row of data for a given username in the form of a list of strings to interpret
  */
 
 public class ReadPrescriptionTask extends AsyncTask<String, Void, Exception> {

--- a/sheets436/src/main/java/edu/umd/cmsc436/sheets/ReadPrescriptionTask.java
+++ b/sheets436/src/main/java/edu/umd/cmsc436/sheets/ReadPrescriptionTask.java
@@ -1,0 +1,99 @@
+package edu.umd.cmsc436.sheets;
+
+import android.app.Activity;
+import android.os.AsyncTask;
+
+import com.google.api.client.extensions.android.http.AndroidHttp;
+import com.google.api.client.googleapis.extensions.android.gms.auth.GoogleAccountCredential;
+import com.google.api.client.googleapis.extensions.android.gms.auth.GooglePlayServicesAvailabilityIOException;
+import com.google.api.client.googleapis.extensions.android.gms.auth.UserRecoverableAuthIOException;
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.services.sheets.v4.model.ValueRange;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Read a prescription object and return a row of data in the form of a list of strings to interpret
+ */
+
+public class ReadPrescriptionTask extends AsyncTask<String, Void, Exception> {
+
+    private com.google.api.services.sheets.v4.Sheets sheetsService;
+    private String spreadsheetId;
+    private Sheets.Host host;
+    private Activity hostActivity;
+    private List<String> results;
+
+    ReadPrescriptionTask (GoogleAccountCredential credential, String spreadsheetId, String applicationName, Sheets.Host host, Activity hostActivity) {
+        this.spreadsheetId = spreadsheetId;
+        this.host = host;
+        this.hostActivity = hostActivity;
+
+        HttpTransport transport = AndroidHttp.newCompatibleTransport();
+        JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
+        sheetsService = new com.google.api.services.sheets.v4.Sheets.Builder(
+                transport, jsonFactory, credential)
+                .setApplicationName(applicationName)
+                .build();
+    }
+
+    @Override
+    protected Exception doInBackground(String... params) {
+
+        try {
+            for (String id : params) {
+                ValueRange response = sheetsService.spreadsheets()
+                        .values()
+                        .get(spreadsheetId, "Sheet1!A2:A")
+                        .execute();
+                List<List<Object>> sheet = response.getValues();
+                int cur_row = 2;
+                if (sheet != null) {
+                    for (List row : sheet) {
+                        if (row.size() == 0 || row.get(0).toString().length() == 0 || row.get(0).toString().equals(id)) {
+                            break;
+                        }
+
+                        cur_row ++;
+                    }
+                }
+
+                ValueRange vals = sheetsService.spreadsheets().values()
+                        .get(spreadsheetId, "Sheet1!A" + cur_row + ":M" + cur_row)
+                        .execute();
+
+                sheet = vals.getValues();
+                if (sheet.size() != 1) {
+                    throw new Exception("nothing");
+                }
+
+                results = new ArrayList<>();
+                for (Object o : sheet.get(0)) {
+                    results.add(o == null ? null : o.toString());
+                }
+            }
+        } catch (IOException ioe) {
+            return ioe;
+        } catch (Exception e) {
+            return e;
+        }
+
+        return null;
+    }
+
+    @Override
+    protected void onPostExecute(Exception e) {
+        if (e != null && e instanceof GooglePlayServicesAvailabilityIOException) {
+            Sheets.showGooglePlayErrorDialog(host, hostActivity);
+        } else if (e != null && e instanceof UserRecoverableAuthIOException) {
+            hostActivity.startActivityForResult(((UserRecoverableAuthIOException) e).getIntent(),
+                    host.getRequestCode(Sheets.Action.REQUEST_AUTHORIZATION));
+        } else {
+            host.onPrescriptionReady(results);
+        }
+    }
+}

--- a/sheets436/src/main/java/edu/umd/cmsc436/sheets/ReadPrescriptionTask.java
+++ b/sheets436/src/main/java/edu/umd/cmsc436/sheets/ReadPrescriptionTask.java
@@ -27,11 +27,18 @@ public class ReadPrescriptionTask extends AsyncTask<String, Void, Exception> {
     private Sheets.Host host;
     private Activity hostActivity;
     private List<String> results;
+    private Sheets.OnPrescriptionFetchedListener mListener;
 
-    ReadPrescriptionTask (GoogleAccountCredential credential, String spreadsheetId, String applicationName, Sheets.Host host, Activity hostActivity) {
+    ReadPrescriptionTask (GoogleAccountCredential credential,
+                          String spreadsheetId,
+                          String applicationName,
+                          Sheets.Host host,
+                          Activity hostActivity,
+                          Sheets.OnPrescriptionFetchedListener listener) {
         this.spreadsheetId = spreadsheetId;
         this.host = host;
         this.hostActivity = hostActivity;
+        mListener = listener;
 
         HttpTransport transport = AndroidHttp.newCompatibleTransport();
         JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
@@ -93,7 +100,7 @@ public class ReadPrescriptionTask extends AsyncTask<String, Void, Exception> {
             hostActivity.startActivityForResult(((UserRecoverableAuthIOException) e).getIntent(),
                     host.getRequestCode(Sheets.Action.REQUEST_AUTHORIZATION));
         } else {
-            host.onPrescriptionReady(results);
+            mListener.onPrescriptionFetched(results);
         }
     }
 }

--- a/sheets436/src/main/java/edu/umd/cmsc436/sheets/Sheets.java
+++ b/sheets436/src/main/java/edu/umd/cmsc436/sheets/Sheets.java
@@ -185,6 +185,14 @@ public class Sheets implements GoogleApiClient.ConnectionCallbacks, GoogleApiCli
                 // Unable to resolve, message user appropriately
                 host.notifyFinished(e);
             }
+        } else if (connectionResult.getErrorCode() == ConnectionResult.INTERNAL_ERROR) {
+            // API reference suggests retrying.  This works for my problems as of 27 April 20:50,
+            // but I actually need to redo some of the authentication stuff proper like
+            // (forcing a broader scope with new Scope("...") is pretty much cheating
+            // and the correct way makes storing accounts easier/possible)
+            resume();
+        } else {
+            Log.e(getClass().getCanonicalName(), "Connection error " + connectionResult.getErrorCode() + ": " + connectionResult.getErrorMessage());
         }
     }
 

--- a/sheets436/src/main/java/edu/umd/cmsc436/sheets/Sheets.java
+++ b/sheets436/src/main/java/edu/umd/cmsc436/sheets/Sheets.java
@@ -56,6 +56,7 @@ public class Sheets implements GoogleApiClient.ConnectionCallbacks, GoogleApiCli
     private Bitmap cache_image;
     private float cache_value;
     private float[] cache_trials;
+    private OnPrescriptionFetchedListener cache_listener;
     private String appName;
     private String spreadsheetId;
     private String privateSpreadsheetId;
@@ -88,14 +89,15 @@ public class Sheets implements GoogleApiClient.ConnectionCallbacks, GoogleApiCli
         }
     }
 
-    public void fetchPrescription (String patientId) {
+    public void fetchPrescription (String patientId, OnPrescriptionFetchedListener listener) {
         cache_service = ServiceType.FetchPrescription;
         cache_type = null;
         cache_userId = patientId;
         cache_value = 0;
+        cache_listener = listener;
 
         if (checkConnection()) {
-            ReadPrescriptionTask readPrescriptionTask = new ReadPrescriptionTask(credentials, spreadsheetId, appName, host, hostActivity);
+            ReadPrescriptionTask readPrescriptionTask = new ReadPrescriptionTask(credentials, spreadsheetId, appName, host, hostActivity, listener);
             readPrescriptionTask.execute(patientId);
         }
     }
@@ -195,7 +197,7 @@ public class Sheets implements GoogleApiClient.ConnectionCallbacks, GoogleApiCli
                 writeTrials(cache_type, cache_userId, cache_trials);
                 break;
             case FetchPrescription:
-                fetchPrescription(cache_userId);
+                fetchPrescription(cache_userId, cache_listener);
                 break;
             default:
                 break;
@@ -255,8 +257,10 @@ public class Sheets implements GoogleApiClient.ConnectionCallbacks, GoogleApiCli
         int getRequestCode(Action action);
 
         void notifyFinished(Exception e);
+    }
 
-        void onPrescriptionReady (List<String> result);
+    public interface OnPrescriptionFetchedListener {
+        void onPrescriptionFetched (@Nullable List<String> raw_data);
     }
 
     public enum Action {

--- a/sheets436/src/main/java/edu/umd/cmsc436/sheets/Sheets.java
+++ b/sheets436/src/main/java/edu/umd/cmsc436/sheets/Sheets.java
@@ -148,7 +148,7 @@ public class Sheets implements GoogleApiClient.ConnectionCallbacks, GoogleApiCli
         }
     }
 
-    public void launchDriveApkTask () {
+    private void launchDriveApkTask () {
         cache_service = null;
         DriveApkTask driveApkTask = new DriveApkTask(credentials, appName, host, hostActivity);
         driveApkTask
@@ -176,10 +176,7 @@ public class Sheets implements GoogleApiClient.ConnectionCallbacks, GoogleApiCli
                 host.notifyFinished(e);
             }
         } else if (connectionResult.getErrorCode() == ConnectionResult.INTERNAL_ERROR) {
-            // API reference suggests retrying.  This works for my problems as of 27 April 20:50,
-            // but I actually need to redo some of the authentication stuff proper like
-            // (forcing a broader scope with new Scope("...") is pretty much cheating
-            // and the correct way makes storing accounts easier/possible)
+            // API reference suggests retrying.
             resume();
         } else {
             Log.e(getClass().getCanonicalName(), "Connection error " + connectionResult.getErrorCode() + ": " + connectionResult.getErrorMessage());

--- a/sheets436/src/main/java/edu/umd/cmsc436/sheets/Sheets.java
+++ b/sheets436/src/main/java/edu/umd/cmsc436/sheets/Sheets.java
@@ -21,13 +21,13 @@ import android.util.Log;
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GoogleApiAvailability;
 import com.google.android.gms.common.api.GoogleApiClient;
-import com.google.android.gms.common.api.Scope;
 import com.google.android.gms.drive.Drive;
 import com.google.api.client.googleapis.extensions.android.gms.auth.GoogleAccountCredential;
 import com.google.api.client.util.ExponentialBackOff;
+import com.google.api.services.drive.DriveScopes;
 import com.google.api.services.sheets.v4.SheetsScopes;
 
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -81,7 +81,7 @@ public class Sheets implements GoogleApiClient.ConnectionCallbacks, GoogleApiCli
         this.privateSpreadsheetId = privateSpreadsheetId;
 
         credentials = GoogleAccountCredential.usingOAuth2(hostActivity,
-                Collections.singletonList(SheetsScopes.SPREADSHEETS)).setBackOff(new ExponentialBackOff());
+                Arrays.asList(SheetsScopes.SPREADSHEETS, DriveScopes.DRIVE)).setBackOff(new ExponentialBackOff());
     }
 
     public void writeData (TestType testType, String userId, float value) {
@@ -114,23 +114,9 @@ public class Sheets implements GoogleApiClient.ConnectionCallbacks, GoogleApiCli
         cache_versionmap = versionMap;
         cache_finishlistener = listener;
 
-        new GoogleApiClient.Builder(hostActivity)
-                .addApi(Drive.API)
-                .addScope(new Scope("https://www.googleapis.com/auth/drive.readonly"))
-                .addConnectionCallbacks(new GoogleApiClient.ConnectionCallbacks() {
-                    @Override
-                    public void onConnected(@Nullable Bundle bundle) {
-                        launchDriveApkTask();
-                    }
-
-                    @Override
-                    public void onConnectionSuspended(int i) {
-                        // nothing
-                    }
-                })
-                .addOnConnectionFailedListener(this)
-                .build()
-                .connect();
+        if (checkConnection()) {
+            launchDriveApkTask();
+        }
     }
 
     public void writeTrials (TestType testType, String userId, float[] trials) {

--- a/sheets436/src/main/java/edu/umd/cmsc436/sheets/UploadToDriveTask.java
+++ b/sheets436/src/main/java/edu/umd/cmsc436/sheets/UploadToDriveTask.java
@@ -19,9 +19,9 @@ import java.util.Collections;
 
 public class UploadToDriveTask extends AsyncTask<UploadToDriveTask.DrivePayload, Void, Exception> {
 
-    private com.google.api.services.drive.Drive driveService = null;
+    protected com.google.api.services.drive.Drive driveService = null;
     private Sheets.Host host;
-    private Activity hostActivity;
+    protected Activity hostActivity;
 
     public UploadToDriveTask(GoogleAccountCredential credential, String applicationName, Sheets.Host host, Activity hostActivity) {
 


### PR DESCRIPTION
This code has been living in a fork for a while.  Adds `Sheets#fetchPrescription()` and `Sheets#fetchApks()`, for use by the frontend.